### PR TITLE
Add completion and tweak behavior for fullpath

### DIFF
--- a/plugin/oldfilesearch.vim
+++ b/plugin/oldfilesearch.vim
@@ -75,12 +75,17 @@ function! s:GetOldFiles(patterns)
         call filter(candidates, 'v:val ' . rxcmp . ' l:p')
     endfor
     " (2) At least one pattern must match the tail component of the path.
-    " (Skip this if pattern contains path separator(s))
     let tailmatches = {}
     for l:f in candidates
         let ft = fnamemodify(l:f, ':t')
         for l:p in a:patterns
-            if l:p =~# '[/\\]' || (hasupcase ? ft =~# l:p : ft =~? l:p)
+            " Check for a simple match of the tail component.  Also check for
+            " patterns with path separator that span over the tail path.
+            let l:pf = l:p . '[^/\\]*$'
+            let l:ismatch = hasupcase ?
+                        \ (ft =~# l:p || l:f =~# l:pf) :
+                        \ (ft =~? l:p || l:f =~? l:pf)
+            if l:ismatch
                 let tailmatches[l:f] = 1
                 break
             endif

--- a/plugin/oldfilesearch.vim
+++ b/plugin/oldfilesearch.vim
@@ -32,29 +32,28 @@ command! -nargs=+ -complete=customlist,s:OldFileComplete
 \ OldFileSearch call s:OldFileSearch([<f-args>])
 
 function! s:OldFileSearch(patterns)
-    let result = s:GetOldFiles(a:patterns)
-    call s:FilterTailMatches(result)
-    if empty(result.candidates)
+    let [oldindex, candidates] = s:GetOldFiles(a:patterns)
+    if empty(candidates)
         echo "No matching old file."
         return
-    elseif len(result.candidates) == 1
-        edit `=result.candidates[0]`
+    elseif len(candidates) == 1
+        edit `=candidates[0]`
     else
         let fmtexpr = '(v:key + 1) . ") " . ('
-                    \ . '(bufnr(v:val) > 0) ? bufnr(v:val) : "<" . result.oldindex[v:val])'
+                    \ . '(bufnr(v:val) > 0) ? bufnr(v:val) : "<" . oldindex[v:val])'
                     \ . ' . " " . fnamemodify(v:val, ":~:.")'
-        let choicelines = map(copy(result.candidates), fmtexpr)
+        let choicelines = map(copy(candidates), fmtexpr)
         let idx = inputlist(['Select old file:'] + choicelines) - 1
-        if idx < 0 || idx >= len(result.candidates)
+        if idx < 0 || idx >= len(candidates)
             return
         endif
-        edit `=result.candidates[idx]`
+        edit `=candidates[idx]`
     endif
 endfunction
 
 function! s:OldFileComplete(arglead, cmdline, cursorpos)
-    let args = split(substitute(a:cmdline, '^OldFileSearch\s\+', '', ''))
-    return s:GetOldFiles(args).candidates
+    let pattern = a:arglead !=# '' ? escape(a:arglead, '.') : '.*'
+    return s:GetOldFiles([pattern])[1]
 endfunction
 
 function! s:GetOldFiles(patterns)
@@ -76,28 +75,15 @@ function! s:GetOldFiles(patterns)
     for l:p in l:nomagic_patterns
         call filter(candidates, 'v:val ' . rxcmp . ' l:p')
     endfor
-    " (2) Discard non-existing files.
-    call filter(candidates, 'filereadable(v:val)')
-    let candidates = candidates[:(&lines - 1)]
-    return {
-    \   'oldindex': oldindex,
-    \   'hasupcase': hasupcase,
-    \   'nomagic_patterns': nomagic_patterns,
-    \   'candidates': candidates
-    \}
-endfunction
-
-" At least one pattern must match the tail component of the path.
-" NOTE: This function destroys a:result.candidates
-function! s:FilterTailMatches(result)
+    " (2) At least one pattern must match the tail component of the path.
     let tailmatches = {}
-    for l:f in a:result.candidates
+    for l:f in candidates
         let ft = fnamemodify(l:f, ':t')
-        for l:p in a:result.nomagic_patterns
+        for l:p in l:nomagic_patterns
             " Check for a simple match of the tail component.  Also check for
             " patterns with path separator that span over the tail path.
             let l:pf = l:p . '\m[^/\\]*$'
-            let l:ismatch = a:result.hasupcase ?
+            let l:ismatch = hasupcase ?
                         \ (ft =~# l:p || l:f =~# l:pf) :
                         \ (ft =~? l:p || l:f =~? l:pf)
             if l:ismatch
@@ -106,5 +92,9 @@ function! s:FilterTailMatches(result)
             endif
         endfor
     endfor
-    call filter(a:result.candidates, 'has_key(tailmatches, v:val)')
+    call filter(candidates, 'has_key(tailmatches, v:val)')
+    " (3) Discard non-existing files.
+    call filter(candidates, 'filereadable(v:val)')
+    let candidates = candidates[:(&lines - 1)]
+    return [oldindex, candidates]
 endfunction

--- a/plugin/oldfilesearch.vim
+++ b/plugin/oldfilesearch.vim
@@ -71,17 +71,18 @@ function! s:GetOldFiles(patterns)
     " (1) All patterns must match the full path.
     let hasupcase = !empty(filter(copy(a:patterns), 'v:val =~ "[[:upper:]]"'))
     let rxcmp = hasupcase ? '=~#' : '=~?'
-    for l:p in a:patterns
+    let l:nomagic_patterns = map(copy(a:patterns), '"\\M" . v:val')
+    for l:p in l:nomagic_patterns
         call filter(candidates, 'v:val ' . rxcmp . ' l:p')
     endfor
     " (2) At least one pattern must match the tail component of the path.
     let tailmatches = {}
     for l:f in candidates
         let ft = fnamemodify(l:f, ':t')
-        for l:p in a:patterns
+        for l:p in l:nomagic_patterns
             " Check for a simple match of the tail component.  Also check for
             " patterns with path separator that span over the tail path.
-            let l:pf = l:p . '[^/\\]*$'
+            let l:pf = l:p . '\m[^/\\]*$'
             let l:ismatch = hasupcase ?
                         \ (ft =~# l:p || l:f =~# l:pf) :
                         \ (ft =~? l:p || l:f =~? l:pf)

--- a/plugin/oldfilesearch.vim
+++ b/plugin/oldfilesearch.vim
@@ -54,8 +54,11 @@ endfunction
 
 
 function! s:OldFileComplete(arglead, cmdline, cursorpos)
-    let pattern = a:arglead !=# '' ? escape(a:arglead, '.') : '.*'
-    return s:GetOldFiles([pattern])[1]
+    let start = matchend(a:cmdline, 'Ol\%[dFileSearch]\s*')
+    let cmdargs = split(a:cmdline[start:], '\s\+')
+    let patterns = empty(cmdargs) ? [''] : cmdargs
+    let [oldindex, candidates] = s:GetOldFiles(patterns)
+    return candidates
 endfunction
 
 

--- a/plugin/oldfilesearch.vim
+++ b/plugin/oldfilesearch.vim
@@ -31,6 +31,7 @@ let loaded_oldfilesearch = 1
 command! -nargs=+ -complete=customlist,s:OldFileComplete
 \ OldFileSearch call s:OldFileSearch([<f-args>])
 
+
 function! s:OldFileSearch(patterns)
     let [oldindex, candidates] = s:GetOldFiles(a:patterns)
     if empty(candidates)
@@ -51,10 +52,12 @@ function! s:OldFileSearch(patterns)
     endif
 endfunction
 
+
 function! s:OldFileComplete(arglead, cmdline, cursorpos)
     let pattern = a:arglead !=# '' ? escape(a:arglead, '.') : '.*'
     return s:GetOldFiles([pattern])[1]
 endfunction
+
 
 function! s:GetOldFiles(patterns)
     " build a unique list of candidate old files
@@ -67,26 +70,22 @@ function! s:GetOldFiles(patterns)
         call add(candidates, ffull)
         let oldindex[ffull] = oidx
     endfor
-    " Use smart-case matching.
+    " Adjust patterns to perform smart-case, nomagic matching.
+    let l:scnomagic_patterns = map(copy(a:patterns),
+                \ '((v:val =~ "[[:upper:]]") ? "\\C" : "\\c") . "\\M" . v:val')
     " (1) All patterns must match the full path.
-    let hasupcase = !empty(filter(copy(a:patterns), 'v:val =~ "[[:upper:]]"'))
-    let rxcmp = hasupcase ? '=~#' : '=~?'
-    let l:nomagic_patterns = map(copy(a:patterns), '"\\M" . v:val')
-    for l:p in l:nomagic_patterns
-        call filter(candidates, 'v:val ' . rxcmp . ' l:p')
+    for l:p in l:scnomagic_patterns
+        call filter(candidates, 'v:val =~ l:p')
     endfor
     " (2) At least one pattern must match the tail component of the path.
     let tailmatches = {}
     for l:f in candidates
         let ft = fnamemodify(l:f, ':t')
-        for l:p in l:nomagic_patterns
+        for l:p in l:scnomagic_patterns
             " Check for a simple match of the tail component.  Also check for
             " patterns with path separator that span over the tail path.
             let l:pf = l:p . '\m[^/\\]*$'
-            let l:ismatch = hasupcase ?
-                        \ (ft =~# l:p || l:f =~# l:pf) :
-                        \ (ft =~? l:p || l:f =~? l:pf)
-            if l:ismatch
+            if ft =~ l:p || l:f =~ l:pf
                 let tailmatches[l:f] = 1
                 break
             endif


### PR DESCRIPTION
Hello @pavoljuhas

Thanks for the great plugin!
I had been looking for a history plugin like this because it's so simple.
No need to save histories to separate files.

I've added (full) filepath completion to `:OldFileSearch`.
This pull request allows `<Tab>` key to work.

```
:OldFileSearch <Tab>
```

With that change, I had no choice but to change the behavior
**only when a fullpath was given**; skip the following process.

> (2) At least one pattern must match the tail component of the path.
