### PR TITLE
Open it if a specified pattern is a filepath

### DIFF
--- a/plugin/oldfilesearch.vim
+++ b/plugin/oldfilesearch.vim
@@ -35,6 +35,9 @@ command! -nargs=+ -complete=customlist,s:OldFileComplete
 
 
 function! s:OldFileSearch(patterns)
+    if len(a:patterns) == 1 && filereadable(a:patterns[0])
+        edit `=a:patterns[0]`
+    endif
     let [oldindex, candidates] = s:GetOldFiles(a:patterns)
     if empty(candidates)
         echo "No matching old file."


### PR DESCRIPTION
Currently oldfilesearch.vim only sees `v:oldfiles` entries.
But if a single pattern was specified and it is a filepath,
I think it is useful to open it directly.