### PR TITLE
Include open buffers as match candidates.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,13 @@
 # oldfilesearch.vim
 
-This plugin provides the `:OldFileSearch` command for filtering the
-`:oldfiles` list of files and displaying selection menu to open one
-of them.  The displayed files must exist and must also match all
-patterns in their full paths and at least one pattern in their tail
-names.  The patterns are matched as 'nomagic' regular expressions.  The
-search is case insensitive unless there is an upper-case character in
-the pattern.  The matching files are displayed together with their
-oldfile index `#<n` or with buffer number `#n` when already loaded
-in the editor.
+Add `:OldFileSearch` command to filter a list of `:oldfiles` and
+regular buffers and display a selection menu to open one of them.
+The displayed files must exist and must match all patterns in their
+full paths and at least one pattern in their tail name.  The patterns
+are matched as 'nomagic' regular expressions.  The search is case
+insensitive unless there is an upper-case character in the pattern.
+The matching files are displayed together with their oldfile index
+`#<n` or with buffer number `#n` when already loaded in the editor.
 
 **Note:** As of Vim 8 a similar selection can be accomplished using
 the built-in command `:filter /pattern/ browse oldfiles`.  In a subtle

--- a/plugin/oldfilesearch.vim
+++ b/plugin/oldfilesearch.vim
@@ -1,5 +1,5 @@
 " oldfilesearch.vim -- search and edit a file from the :oldfiles list
-" Date: 2017-07-18
+" Date: 2017-07-20
 " Maintainer: Pavol Juhas <pavol.juhas@gmail.com>
 " Contributor: Takuya Fujiwara <tyru.exe@gmail.com>
 " URL: https://github.com/pavoljuhas/oldfilesearch.vim
@@ -77,8 +77,8 @@ function! s:GetOldFiles(patterns) abort
     endfor
     " Prepend all regular buffers that are not yet candidates.
     for l:b in reverse(range(1, bufnr('$')))
-        " skip non-existing and special buffers.
-        if !bufexists(l:b) || !empty(getbufvar(l:b, '&buftype'))
+        " skip non-existing, unnamed and special buffers.
+        if empty(bufname(l:b)) || !empty(getbufvar(l:b, '&buftype'))
             continue
         endif
         " skip buffers that are already candidates.


### PR DESCRIPTION
Vim buffers that are not yet in `:oldfiles` will be there in
the next session.  Let's include them right away.  Avoid
mental exercise figuring if the desired file is old or not.